### PR TITLE
Modifications to quest_db to allow defining target items and exp rewards

### DIFF
--- a/src/map/quest.cpp
+++ b/src/map/quest.cpp
@@ -339,6 +339,69 @@ uint64 QuestDatabase::parseBodyNode(const ryml::NodeRef& node) {
 		}
 	}
 
+	if (this->nodeExists(node, "TargetItems")) {
+		const auto& targetItems = node["TargetItems"];
+
+		for (const auto& itemNode : targetItems) {
+			t_itemid nameid;
+			
+			if (this->nodeExists(itemNode, "Item")) {
+				std::string item_name;
+
+				if (!this->asString(itemNode, "Item", item_name))
+					return 0;
+
+				std::shared_ptr<item_data> item = item_db.search_aegisname( item_name.c_str() );
+
+				if (!item) {
+					this->invalidWarning(itemNode["Item"], "Item %s does not exist, skipping.\n", item_name.c_str());
+					continue;
+				}
+
+				nameid = item->nameid;
+			} else {
+				continue;
+			}
+
+			std::shared_ptr<s_quest_targetitem> target;
+			std::vector<std::shared_ptr<s_quest_targetitem>>::iterator it = std::find_if(quest->targetitem.begin(), quest->targetitem.end(), [&](std::shared_ptr<s_quest_targetitem> const &v) {
+				return (*v).nameid == nameid;
+			});
+
+			bool targetExists = false;
+			if (it != quest->targetitem.end()) {
+				target = (*it);
+				targetExists = true;
+			}
+			else {
+				target = std::make_shared<s_quest_targetitem>();
+				target->nameid = nameid;
+			}
+
+			if (this->nodeExists(itemNode, "Count")) {
+				uint16 count;
+
+				if (!this->asUInt16(itemNode, "Count", count))
+					return 0;
+
+				if (!itemdb_isstackable(target->nameid)) {
+					this->invalidWarning(itemNode["Count"], "Item %s is not stackable, capping to 1.\n", itemdb_name(target->nameid));
+					count = 1;
+				}
+
+				if (targetExists)
+					target->count += count;
+				else
+					target->count = count;
+			} else {
+				if (!targetExists)
+					target->count = 1;
+			}
+
+			quest->targetitem.push_back(target);
+		}
+	}
+
 	if (this->nodeExists(node, "Drops")) {
 		const auto& drops = node["Drops"];
 
@@ -434,6 +497,7 @@ uint64 QuestDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			quest->dropitem.push_back(target);
 		}
 	}
+	
 
 	if (this->nodeExists(node, "BaseExp")) {
 		uint64 baseExp;
@@ -956,6 +1020,56 @@ int quest_reward(map_session_data *sd, int quest_id)
 #endif
 
 	return 0;
+}
+
+/**
+ * Checks if a
+ * @param sd : Player's data
+ * @param quest_id : ID of the quest to remove
+ * @param items: holds item data for script to delete if needed
+ * @return 0 in case of items not found, 1 if items found, nonzero otherwise
+ */
+int quest_count_items(map_session_data *sd, int quest_id, std::vector<item> *items)
+{
+	std::shared_ptr<s_quest_db> qi = quest_search(quest_id);
+
+	if (!qi) {
+		ShowError("quest_count_items: quest %d not found in DB.\n", quest_id);
+		return -1;
+	}
+
+	for (const auto& target : qi->targetitem) {
+		std::shared_ptr<item_data> id = item_db.find(target->nameid);
+		int count = 0;
+
+		if (!id) {
+			ShowError("quest_count_items: Invalid item '%s'.\n", target->nameid); // returns string, regardless of what it was
+			return -1;
+		}
+
+		for (int i = 0; i < MAX_INVENTORY; i++) {
+			item *itm = &sd->inventory.u.items_inventory[i];
+
+			if (itm == nullptr || itm->nameid == 0 || itm->amount < 1)
+				continue;
+			if (itm->nameid == target->nameid && itm->expire_time == 0)
+				count += itm->amount;
+
+			if (count >= target->count)
+				continue;
+		}
+		if (count < target->count)
+			return 0;
+
+		if (items != nullptr){
+			struct item item;
+			item.nameid = target->nameid;
+			item.amount = target->count;
+			(*items).push_back(item);
+		}
+	}
+
+	return 1;
 }
 
 /**

--- a/src/map/quest.hpp
+++ b/src/map/quest.hpp
@@ -25,6 +25,11 @@ struct s_quest_dropitem {
 	//bool isGUID;
 };
 
+struct s_quest_targetitem {
+	t_itemid nameid;
+	uint16 count;
+};
+
 struct s_quest_objective {
 	uint16 index;
 	uint16 mob_id;
@@ -43,6 +48,7 @@ struct s_quest_db {
 	time_t time;
 	bool time_at;
 	std::vector<std::shared_ptr<s_quest_objective>> objectives;
+	std::vector<std::shared_ptr<s_quest_targetitem>> targetitem;
 	std::vector<std::shared_ptr<s_quest_dropitem>> dropitem;
 	std::string name;
 	t_exp baseExp;
@@ -81,6 +87,7 @@ void quest_update_objective(map_session_data *sd, struct mob_data* md);
 int quest_update_status(map_session_data *sd, int quest_id, e_quest_state status);
 int quest_check(map_session_data *sd, int quest_id, e_quest_check_type type);
 int quest_reward(map_session_data *sd, int quest_id);
+int quest_count_items(map_session_data *sd, int quest_id, std::vector<item> *items);
 
 std::shared_ptr<s_quest_db> quest_search(int quest_id);
 

--- a/src/map/quest.hpp
+++ b/src/map/quest.hpp
@@ -45,6 +45,8 @@ struct s_quest_db {
 	std::vector<std::shared_ptr<s_quest_objective>> objectives;
 	std::vector<std::shared_ptr<s_quest_dropitem>> dropitem;
 	std::string name;
+	t_exp baseExp;
+	t_exp jobExp;
 };
 
 // Questlog check types
@@ -78,6 +80,7 @@ int quest_update_objective_sub(struct block_list *bl, va_list ap);
 void quest_update_objective(map_session_data *sd, struct mob_data* md);
 int quest_update_status(map_session_data *sd, int quest_id, e_quest_state status);
 int quest_check(map_session_data *sd, int quest_id, e_quest_check_type type);
+int quest_reward(map_session_data *sd, int quest_id);
 
 std::shared_ptr<s_quest_db> quest_search(int quest_id);
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -8337,7 +8337,7 @@ static bool buildin_delitem_search(map_session_data* sd, struct item* it, uint8 
 	bool delete_items = false;
 	int i, amount, size;
 	struct item *items;
-
+	
 	// prefer always non-equipped items
 	it->equip = 0;
 
@@ -20804,6 +20804,36 @@ BUILDIN_FUNC(questreward)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * questcountitem <ID>{,<int>,<char_id>};
+ **/
+BUILDIN_FUNC(questcountitem)
+{
+	map_session_data *sd;
+	std::vector<item> items;
+
+	if (!script_charid2sd(4,sd))
+		return SCRIPT_CMD_FAILURE;
+
+	bool deleteItems = script_getnum( st, 3 ) != 0;
+	
+	int countResult = quest_count_items(sd, script_getnum( st, 2 ), &items);
+
+	if (countResult == -1)
+		return SCRIPT_CMD_FAILURE;
+
+	script_pushint(st, countResult);
+
+	if (deleteItems) {
+		for(auto& i:items){
+			if (!buildin_delitem_search(sd, &i, 0, TABLE_INVENTORY))
+				return SCRIPT_CMD_FAILURE;
+		}
+	}
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
 
 /**
  * isbegin_quest(<ID>{,<char_id>})
@@ -27484,6 +27514,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(showevent, "i??"),
 	BUILDIN_DEF(questinfo_refresh, "?"),
 	BUILDIN_DEF(questreward, "i?"),
+	BUILDIN_DEF(questcountitem,"ii?"),
 
 	//Bound items [Xantara] & [Akinari]
 	BUILDIN_DEF2(getitem,"getitembound","vii?"),

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -20787,6 +20787,25 @@ BUILDIN_FUNC(checkquest)
 }
 
 /**
+ * questreward <ID>{,<char_id>};
+ **/
+BUILDIN_FUNC(questreward)
+{
+	map_session_data *sd;
+
+	if (!script_charid2sd(3,sd))
+		return SCRIPT_CMD_FAILURE;
+
+	if( quest_reward(sd, script_getnum(st, 2))  == -1 ){
+		script_reportsrc(st);
+		script_reportfunc(st);
+	}
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
+
+/**
  * isbegin_quest(<ID>{,<char_id>})
  **/
 BUILDIN_FUNC(isbegin_quest)
@@ -27464,6 +27483,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(changequest, "ii?"),
 	BUILDIN_DEF(showevent, "i??"),
 	BUILDIN_DEF(questinfo_refresh, "?"),
+	BUILDIN_DEF(questreward, "i?"),
 
 	//Bound items [Xantara] & [Akinari]
 	BUILDIN_DEF2(getitem,"getitembound","vii?"),


### PR DESCRIPTION
Allows for checking and deleting items given a quest requirement and granting exp rewards from quest through script commands.

Still needs some checks on input.